### PR TITLE
Added AUTO_CALIBRATE_GYRO option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ This is a summary of new features and bugfixes. Read the README to learn how to 
 
 ## 3.2.0
 
-Jibb added the new GYRO_SPACE setting for more one-size-fits-all gyro aiming. Default behaviour is unchanged, but set to WORLD_TURN to try the new algorithm (or WORLD_LEAN if you prefer to lean your controller side to side to turn the camera).
+Jibb added the new GYRO_SPACE setting for more one-size-fits-all gyro aiming. Default behaviour is unchanged, but set to WORLD_TURN to try the new algorithm (or WORLD_LEAN if you prefer to lean your controller side to side to turn the camera). He also added the option for automatic gyro calibration.
 
 ### Features
 
 * GYRO_SPACE can be set to LOCAL (default), WORLD_TURN (recommended), or WORLD_LEAN.
+* AUTO_CALIBRATE_GYRO can be set to ON to activate automatic calibration, which will try and detect when the controller is held still or put down and recalibrate automatically.
 
 ## 3.1.1
 

--- a/JoyShockMapper/include/MotionIf.h
+++ b/JoyShockMapper/include/MotionIf.h
@@ -26,6 +26,7 @@ public:
 	virtual void ResetContinuousCalibration() = 0;
 	virtual void GetCalibrationOffset(float& xOffset, float& yOffset, float& zOffset) = 0;
 	virtual void SetCalibrationOffset(float xOffset, float yOffset, float zOffset, int weight) = 0;
+	virtual void SetAutoCalibration(bool enabled, float gyroThreshold, float accelThreshold) = 0;
 
 	void virtual ResetMotion() = 0;
 };

--- a/JoyShockMapper/src/MotionImpl.cpp
+++ b/JoyShockMapper/src/MotionImpl.cpp
@@ -73,6 +73,20 @@ public:
 		gamepadMotion.SetCalibrationOffset(xOffset, yOffset, zOffset, weight);
 	}
 
+	virtual void SetAutoCalibration(bool enabled, float gyroThreshold, float accelThreshold) override
+	{
+		if (enabled)
+		{
+			gamepadMotion.SetCalibrationMode(GamepadMotionHelpers::CalibrationMode::Stillness | GamepadMotionHelpers::CalibrationMode::SensorFusion);
+			gamepadMotion.Settings.StillnessGyroDelta = gyroThreshold;
+			gamepadMotion.Settings.StillnessAccelDelta = accelThreshold;
+		}
+		else
+		{
+			gamepadMotion.SetCalibrationMode(GamepadMotionHelpers::CalibrationMode::Manual);
+		}
+	}
+
 	void virtual ResetMotion() override 
 	{
 		gamepadMotion.ResetMotion();

--- a/README.md
+++ b/README.md
@@ -617,11 +617,11 @@ A common use for the motion sensors is to map left and right leans of the contro
 ### 4. Gyro Mouse Inputs
 **The first thing you need to know about gyro mouse inputs** is that a controller's gyro will often need calibrating. This just means telling the application where "zero" is. Just like a scale, the gyro needs a point of reference to compare against in order to accurately give a result. This is done by leaving the controller still, or holding it very still in your hands, and finding the average velocity over a short time of staying still. It needs to be averaged over some time because the gyro will pick up a little bit of "noise" -- tiny variations that aren't caused by any real movement -- but this noise is negligible compared to the shakiness of human hands trying to hold a controller still.
 
-When you first connect controllers to JoyShockMapper, they'll all begin "continuous calibration" -- this just means they're collecting the average velocity over a long period of time. This accumulated average is constantly applied to gyro inputs, so if the controller is left still for long enough, you should be able to play without obvious problems.
-
 If you have gyro mouse enabled and the gyro moves across the screen (even slowly) when the controller is lying still on a solid surface, your device needs calibrating. That's okay -- I do it at the beginning of most play sessions, especially with Nintendo devices, which seem to need it more often.
 
-To calibrate your gyro, place your controller on solid surface so that it's not moving at all, and then use the following commands:
+If you set **AUTO\_CALIBRATE\_GYRO** to **ON**, JoyShockMapper will try to detect when your controller is being held still or left on a steady surface and calibrate the gyro automatically. This is imperfect, though -- every automatic calibration solution will *sometimes* interpret slow and steady movement as the controller being held still. This can interrupt you making small adjustments to your aim or tracking slow/distant targets. It's also only a new feature, and we try not to change default behaviour. Also, it doesn't yet give you any settings to tweak its thresholds. For all of these reasons this setting is **OFF** by default, and it's recommended that you calibrate your gyro manually instead.
+
+To manually calibrate your gyro, place your controller on steady surface so that it's not moving at all, and then use the following commands:
 * **RESTART\_GYRO\_CALIBRATION** - All connected gyro devices will begin collecting gyro data, remembering the average collected so far and treating it as "zero".
 * **FINISH\_GYRO\_CALIBRATION** - Stop collecting gyro data for calibration. JoyShockMapper will use whatever it has already collected from that controller as the "zero" reference point for input from that controller.
 
@@ -919,7 +919,7 @@ T2,TDOWN = 8
 ### 9. Miscellaneous Commands
 There are a few other useful commands that don't fall under the above categories:
 
-* **RESET\_MAPPINGS** - This will reset all JoyShockMapper's settings to their default values. This way you don't have to manually unset button mappings or other settings when making a big change. It can be useful to always start your configuration files with the RESET\_MAPPINGS command. The only exceptions to this are the calibration state and AUTOLOAD.
+* **RESET\_MAPPINGS** - This will reset all JoyShockMapper's settings to their default values. This way you don't have to manually unset button mappings or other settings when making a big change. It can be useful to always start your configuration files with the RESET\_MAPPINGS command. The only exceptions to this are the gyro calibration state / settings and AUTOLOAD.
 * **RECONNECT\_CONTROLLERS** - Controllers connected after JoyShockMapper starts will be ignored until you tell it to RECONNECT\_CONTROLLERS. When this happens, all gyro calibration will reset on all controllers. You can add MERGE or SPLIT to indicate whether you want all joycons under a single controller or separate controllers. The player LED will help you identify whether they are merged or split.
 * **\# comments** - Any line or part of a line that begins with '\#' will be ignored. Use this to organise/annotate your configuration files, or to temporarily remove commands that you may want to add later.
 * **JOYCON\_GYRO\_MASK** (default IGNORE\_LEFT) - Most games that use gyro controls on Switch ignore the left JoyCon's gyro to avoid confusing behaviour when the JoyCons are held separately while playing. This is the default behaviour in JoyShockMapper. But you can also choose to IGNORE\_RIGHT, IGNORE\_BOTH, or USE\_BOTH.
@@ -942,11 +942,11 @@ What more? There are some configuration files that can be run automatically to s
 
 ### 1. OnStartup.txt
 
-When JoyShockMapper first boots up, it will attempt to load the commands found in the file OnStartup.txt. This file should be in the JSM_DIRECTORY, which is next to your executable by default. This is a great place to automatically calibrate the gyro, and load a default configuration for navigating the OS, and whitelisting JoyShockMapper.
+When JoyShockMapper first boots up, it will attempt to load the commands found in the file OnStartup.txt. This file should be in the JSM_DIRECTORY, which is next to your executable by default. This is a great place to automatically calibrate the gyro, load a default configuration for navigating the OS, and/or whitelisting JoyShockMapper.
 
 ### 2. OnReset.txt
 
-This configuration is found in the same location as OnStartup.txt explained above. This file is run each time RESET\_MAPPINGS is called, as well as before OnStartup.txt. This file is a good spot to have a CALIBRATE button for your controller, which you will typically always need.
+This configuration is found in the same location as OnStartup.txt explained above. This file is run each time RESET\_MAPPINGS is called, as well as before OnStartup.txt. This file is a good spot to set a CALIBRATE button for your controller and/or set your GYRO\_SPACE if you're not using the default value.
 
 ### 3. Autoload feature
 


### PR DESCRIPTION
AUTO_CALIBRATE_GYRO defaults to OFF. When set to ON the gyro will automatically calibrate when held very still or left on a steady surface. Thresholds are tuned to be very 'tight' (very difficult to accidentally miscalibrate, but players with unsteady hands will have to put the controller down to trigger calibration). In future we can let players tune their thresholds, and I'm experimenting with automatic thresholds that just detect appropriate values based on the controller's historical movements.

Also made it so GYRO_SPACE resets with RESET_MAPPINGS. AUTO_CALIBRATE_GYRO does not reset with RESET_MAPPINGS, because I figure it falls under the category of "calibration state" that's already ignored by the reset? I'm not married to this, though.