### PR TITLE
Add VK_NONAME define and add Linux information to README.md

### DIFF
--- a/JoyShockMapper/include/PlatformDefinitions.h
+++ b/JoyShockMapper/include/PlatformDefinitions.h
@@ -98,6 +98,7 @@ extern const char *BASE_JSM_CONFIG_FOLDER();
 #define VK_MBUTTON 0x04
 #define VK_XBUTTON1 0x05
 #define VK_XBUTTON2 0x06
+#define VK_NONAME 0xFC
 
 #define U(string) string
 #define _ASSERT_EXPR(condition, message) assert(condition)

--- a/README.md
+++ b/README.md
@@ -94,13 +94,24 @@ Generate the project by runnning the following in a command prompt at the projec
   * To create a Visual Studio x64 configuration: ```cmake .. -G "Visual Studio 16 2019" -A x64 .```
 - Linux:
   * ```mkdir build && cd build```
-  * ```cmake .. -DCMAKE_CXX_COMPILER=clang++ && cmake --build .```
+  * ```cmake .. -DCMAKE_CXX_COMPILER=clang++ -DSDL=1 && cmake --build .```
 
 ### Linux specific notes
+Please note that JoyShockMapper is primarily written for Windows and is a program in rapid development.
+
+While JSM can be built for Linux, please note that the rapid pace of development and limited number of Linux maintainers means that the Linux release may not always build.
+
 In order to build on Linux, the following dependencies must be met, with their respective development packages:
 - gtk+3
 - libappindicator3
 - libevdev
+- libusb
+- SDL2
+
+####Distribution-Specific Package Names:
+
+* Fedora: ```SDL2-devel libappindicator-gtk3-devel libevdev-devel gtk3-devel libusb-devel```
+* Please provide an issue report or pull request to have additional library lists added.
 
 Due to a [bug](https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc) in GCC, the project in its current form will only build with Clang.
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ In order to build on Linux, the following dependencies must be met, with their r
 - libevdev
 - libusb
 - SDL2
+- hidapi
 
 ####Distribution-Specific Package Names:
 
-* Fedora: ```SDL2-devel libappindicator-gtk3-devel libevdev-devel gtk3-devel libusb-devel```
+* Fedora: ```SDL2-devel libappindicator-gtk3-devel libevdev-devel gtk3-devel libusb-devel hidapi-devel```
 * Please provide an issue report or pull request to have additional library lists added.
 
 Due to a [bug](https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc) in GCC, the project in its current form will only build with Clang.


### PR DESCRIPTION
This change fixes Linux building by adding a common define that was missing in the Linux headers.

This also adds some Linux specific information to README.md to help prevent confusion.