### PR TITLE
CMake fixes for Linux building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.12)
+cmake_policy(SET CMP0077 NEW)
 
 project ("JoyShockMapper" CXX)
 

--- a/JoyShockMapper/CMakeLists.txt
+++ b/JoyShockMapper/CMakeLists.txt
@@ -39,20 +39,20 @@ add_executable (
 	include/Mapping.h
 )
 
-if(SDL)
-	target_sources (
-		${BINARY_NAME} PRIVATE
-		src/SDL2Wrapper.cpp
-	)
-	add_definitions(-DSDL2)
-else()
-		target_sources (
-		${BINARY_NAME} PRIVATE
-		src/JslWrapper.cpp
-	)
-endif()
-
 if (WINDOWS)
+	if(SDL)
+		target_sources (
+				${BINARY_NAME} PRIVATE
+				src/SDL2Wrapper.cpp
+		)
+		add_definitions(-DSDL2)
+	else()
+		target_sources (
+				${BINARY_NAME} PRIVATE
+				src/JslWrapper.cpp
+		)
+	endif()
+
     target_sources (
         ${BINARY_NAME} PRIVATE
         src/win32/InputHelpers.cpp
@@ -125,6 +125,19 @@ if (WINDOWS)
 endif ()
 
 if (LINUX)
+	if(SDL OR NOT DEFINED SDL)
+		target_sources (
+				${BINARY_NAME} PRIVATE
+				src/SDL2Wrapper.cpp
+		)
+		add_definitions(-DSDL2)
+	else()
+		target_sources (
+				${BINARY_NAME} PRIVATE
+				src/JslWrapper.cpp
+		)
+	endif()
+
     target_sources (
         ${BINARY_NAME} PRIVATE
         src/linux/Init.cpp
@@ -148,7 +161,7 @@ target_include_directories (
     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}/include"
 )
 
-if(SDL)
+if(SDL OR NOT DEFINED SDL)
 	# SDL2
 	set(HIDAPI ON)
 	CPMAddPackage (

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Generate the project by runnning the following in a command prompt at the projec
   * To create a Visual Studio x64 configuration: ```cmake .. -G "Visual Studio 16 2019" -A x64 .```
 - Linux:
   * ```mkdir build && cd build```
-  * ```cmake .. -DCMAKE_CXX_COMPILER=clang++ -DSDL=1 -DHIDAPI=ON && cmake --build .```
+  * ```cmake .. -DCMAKE_CXX_COMPILER=clang++ && cmake --build .```
 
 ### Linux specific notes
 Please note that JoyShockMapper is primarily written for Windows and is a program in rapid development.
@@ -102,6 +102,7 @@ Please note that JoyShockMapper is primarily written for Windows and is a progra
 While JSM can be built for Linux, please note that the rapid pace of development and limited number of Linux maintainers means that the Linux release may not always build.
 
 In order to build on Linux, the following dependencies must be met, with their respective development packages:
+- clang++ (see below bug)
 - gtk+3
 - libappindicator3
 - libevdev
@@ -111,7 +112,8 @@ In order to build on Linux, the following dependencies must be met, with their r
 
 **Distribution-Specific Package Names:**
 
-* Fedora: ```SDL2-devel libappindicator-gtk3-devel libevdev-devel gtk3-devel libusb-devel hidapi-devel```
+* Fedora: ```clang SDL2-devel libappindicator-gtk3-devel libevdev-devel gtk3-devel libusb-devel hidapi-devel```
+* Arch: ```clang sdl2 libappindicator-gtk3 libevdev gtk3 libusb hidapi```
 * Please provide an issue report or pull request to have additional library lists added.
 
 Due to a [bug](https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc) in GCC, the project in its current form will only build with Clang.


### PR DESCRIPTION
This pull request fixes a few CMake build problems on Linux and eliminates some confusion by changing build behavior.

First, I looked into why HIDAPI wasn't being set, and isolated it to a compatibility with older JSM versions (https://cmake.org/cmake/help/latest/policy/CMP0077.html).Since JSM is mostly being run with modern Linux and CMake versions, this should not affect many people. I have set CMake by default to use New style variable behavior, which should not affect Windows.

Second, SDL is now the default input handler for Linux. Most if not all Linux users are bound to have it installed anyway, and JSL is currently broken under Linux anyway. CMake will now automatically use SDL if ```-DSDL``` is undefined or set to 1.

Third, I have cleaned up readme.md and added Arch packages.

These changes should allow JSM to build cleanly under Linux with less confusion and fewer strange issues although clang++ will still be required.