### PR TITLE
fix linux build (missing <cstring>) and fix invalid deviceHandles index

### DIFF
--- a/JoyShockMapper/src/Mapping.cpp
+++ b/JoyShockMapper/src/Mapping.cpp
@@ -1,6 +1,7 @@
 #include "Mapping.h"
 #include "InputHelpers.h"
 #include <regex>
+#include <cstring>
 
 ostream &operator<<(ostream &out, Mapping mapping)
 {

--- a/JoyShockMapper/src/SDL2Wrapper.cpp
+++ b/JoyShockMapper/src/SDL2Wrapper.cpp
@@ -317,6 +317,7 @@ public:
 			}
 			else
 			{
+                deviceHandleArray[i] = -1;
 				delete device;
 			}
 		}

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <cfloat>
 #include <cuchar>
+#include <cstring>
 
 #ifdef _WIN32
 #include <shellapi.h>
@@ -1594,7 +1595,8 @@ void connectDevices(bool mergeJoycons = true)
 
 		if (numConnected < deviceHandles.size())
 		{
-			deviceHandles.resize(numConnected);
+            deviceHandles.erase(std::remove(deviceHandles.begin(), deviceHandles.end(), -1), deviceHandles.end());
+			//deviceHandles.resize(numConnected);
 		}
 
 		for (auto handle : deviceHandles) // Don't use foreach!


### PR DESCRIPTION
This pull request adds a missing include that breaks building on linux.

It also fixes an invalid index bug in connectDevices() that will segfault the program due to improper cleaning of the deviceHandles vector.