### PR TITLE
Keymap Fixes For Linux

### DIFF
--- a/JoyShockMapper/include/PlatformDefinitions.h
+++ b/JoyShockMapper/include/PlatformDefinitions.h
@@ -98,6 +98,10 @@ extern const char *BASE_JSM_CONFIG_FOLDER();
 #define VK_MBUTTON 0x04
 #define VK_XBUTTON1 0x05
 #define VK_XBUTTON2 0x06
+#define VK_LWIN 0x5B // Left Windows Key
+#define VK_RWIN 0x5C // Right Windows Key
+#define VK_APPS 0x5D // Context Key
+#define VK_SNAPSHOT 0x2C // Printscreen Key
 #define VK_NONAME 0xFC
 
 #define U(string) string

--- a/JoyShockMapper/src/linux/InputHelpers.cpp
+++ b/JoyShockMapper/src/linux/InputHelpers.cpp
@@ -257,9 +257,9 @@ private:
 		case VK_ESCAPE:
 			return KEY_ESC;
 		case VK_PRIOR:
-			return KEY_PREVIOUS;
+			return KEY_PAGEUP;
 		case VK_NEXT:
-			return KEY_NEXT;
+			return KEY_PAGEDOWN;
 		case VK_HOME:
 			return KEY_HOME;
 		case VK_END:
@@ -283,7 +283,15 @@ private:
 		case V_WHEEL_UP:
 			return static_cast<decltype(KEY_0)>(V_WHEEL_UP);
 		case VK_BACK:
-			return KEY_BACK;
+			return KEY_BACKSPACE;
+    case VK_LWIN:
+      return KEY_LEFTMETA;
+    case VK_RWIN:
+      return KEY_RIGHTMETA;
+    case VK_APPS:
+      return KEY_COMPOSE;
+    case VK_SNAPSHOT:
+      return KEY_SYSRQ;
 			//		case NO_HOLD_MAPPED: return NO_HOLD_MAPPED;
 			//		case CALIBRATE: return CALIBRATE;
 			//		case GYRO_INV_X: return GYRO_INV_X;

--- a/JoyShockMapper/src/linux/PlatformDefinitions.cpp
+++ b/JoyShockMapper/src/linux/PlatformDefinitions.cpp
@@ -338,6 +338,22 @@ WORD nameToKey(in_string name)
 	{
 		return VK_BACK;
 	}
+	if (name.compare("LWINDOWS") == 0)
+	{
+		return VK_LWIN;
+	}
+	if (name.compare("RWINDOWS") == 0)
+	{
+		return VK_RWIN;
+	}
+	if (name.compare("CONTEXT") == 0)
+	{
+		return VK_APPS;
+	}
+	if (name.compare("SCREENSHOT") == 0)
+	{
+		return VK_SNAPSHOT;
+	}
 	if (name.compare("NONE") == 0)
 	{
 		return NO_HOLD_MAPPED;


### PR DESCRIPTION
Hello!
Here's a **keymap fix** for **JSM on Linux**!

This commit adds proper support for LWINDOWS, RWINDOWS, APPS, CONTEXT, and SCREENSHOT by mapping the keys to their proper `evdev` equivalents.

As well as that, I have fixed the PAGEUP AND PAGEDOWN keys not producing any output, as well as fixing the confusion between VK_BACK and VK_BACKSPACE.

In total, seven different keys that were unbindable, bound without producing output, or mis-bound to 'BACK' in the case of BACKSPACE have been fixed.
This was developed and tested on Arch Linux, but it should work on other distros OOTB if it uses the evdev system.

| JSM Name    | VK Scancode | VK Name     | EV_KEY Name      | MR?     | Base JSM?  |
|-------------|-------------|-------------|------------------|---------|------------|
| LWINDOWS    | 0x5B        | VK_LWIN     | KEY_LEFTMETA     | Yes     | No         |
| RWINDOWS    | 0x5C        | VK_RWIN     | KEY_RIGHTMETA    | Yes     | No         |
| CONTEXT     | 0x5D        | VK_APPS     | KEY_COMPOSE      | Yes     | No         |
| PAGEUP      | 0x21        | VK_PRIOR    | KEY_PAGEUP       | Yes     | Outputless |
| PAGEDOWN    | 0x22        | VK_NEXT     | KEY_PAGEDOWN     | Yes     | Outputless |
| BACKSPACE   | 0x08        | VK_BACK     | KEY_BACKSPACE    | Yes     | Mismap     |
| SCREENSHOT  | 0x2C        | VK_SNAPSHOT | KEY_SYSRQ        | Yes     | No         |

*REFERENCES:*
https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
https://en.wikipedia.org/wiki/Menu_key

*NOTES:*
CONTEXT key may be incorrect on other keyboards, because it's KEY_COMPOSE on my keyboard, and I have no other keyboards with that key to confidently test it.
It looks like and acts like a MENU key on my keyboard, tested in Firefox and Konsole.
'It works on my machine' kind of deal, so any other Linux users want to try this commit, or if the CONTEXT fix should be omitted until further notice, please tell me.

The commits/PR only change the Linux implementation of JSM.
It seems like the `PlatformDefinitions.h` file has all of the bindings already for the most part.
I ended up adding in the 4 extra definitions for the WINDOWS, APPS and screenshot key there because it's in a conditional compilation block.

I don't have a Windows PC (by choice), but this commit should have no bearing whatsoever on the Windows build.
All code changes are limited to the condition compilation block in `PlatformDefinitions.h` or the `src/linux/{InputHelpers,PlatformDefintions}.cpp` files.

Very surprised such a simple commit fixed a pretty annoying issue like this.
This is one of my first ever contributions to an active project, very excited. If you have any questions or issues, definitely make it known here.

Thanks for the review, thanks for making/maintaining JSM and Merry Christmas :)