### PR TITLE
fix(autoconnect): remove sleep delay

### DIFF
--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -1142,7 +1142,6 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 void connectDevices(bool mergeJoycons = true)
 {
 	handle_to_joyshock.clear();
-	this_thread::sleep_for(100ms);
 	int numConnected = jsl->ConnectDevices();
 	vector<int> deviceHandles(numConnected, 0);
 	if (numConnected > 0)


### PR DESCRIPTION
- Removed unnecessary `this_thread::sleep_for(100ms)` delay that was masking timing issues