### PR TITLE
fix: prevent segfault at startup

### DIFF
--- a/JoyShockMapper/include/Gamepad.h
+++ b/JoyShockMapper/include/Gamepad.h
@@ -3,6 +3,8 @@
 #include "JoyShockMapper.h"
 #include "PlatformDefinitions.h"
 
+#include <chrono>
+
 struct Indicator
 {
 	uint8_t led;

--- a/JoyShockMapper/include/linux/StatusNotifierItem.h
+++ b/JoyShockMapper/include/linux/StatusNotifierItem.h
@@ -52,4 +52,5 @@ private:
 	std::list<ClickCallbackType> callbacks_;
 
 	std::thread thread_;
+	std::function<void()> beforeShow_;
 };

--- a/JoyShockMapper/src/ButtonHelp.cpp
+++ b/JoyShockMapper/src/ButtonHelp.cpp
@@ -1,6 +1,4 @@
-﻿#pragma once
-
-#include <JoyShockMapper.h>
+﻿#include <JoyShockMapper.h>
 
 const map<ButtonID, string> buttonHelpMap{
 	{ ButtonID::UP, "Up on the d-pad" },

--- a/JoyShockMapper/src/TriggerEffectGenerator.cpp
+++ b/JoyShockMapper/src/TriggerEffectGenerator.cpp
@@ -23,6 +23,8 @@
  */
 
 #include "TriggerEffectGenerator.h"
+
+#include <algorithm>
 #include <cstdint>
 #include <cmath>
 

--- a/JoyShockMapper/src/linux/StatusNotifierItem.cpp
+++ b/JoyShockMapper/src/linux/StatusNotifierItem.cpp
@@ -11,7 +11,8 @@ TrayIcon *TrayIcon::getNew(TrayIconData applicationName, std::function<void()> &
 
 
 StatusNotifierItem::StatusNotifierItem(TrayIconData, std::function<void()> &&beforeShow)
-  : thread_{ [this, &beforeShow] {
+  : beforeShow_{std::move(beforeShow)},
+    thread_{ [this] {
 	  int argc = 0;
 	  gtk_init(&argc, nullptr);
 
@@ -34,7 +35,9 @@ StatusNotifierItem::StatusNotifierItem(TrayIconData, std::function<void()> &&bef
 	  app_indicator_set_status(indicator_, APP_INDICATOR_STATUS_ACTIVE);
 	  app_indicator_set_menu(indicator_, menu_.get());
 
-	  beforeShow();
+	  if (beforeShow_) {
+		  beforeShow_();
+	  }
 
 	  gtk_main();
   } }


### PR DESCRIPTION
This PR includes some changes needed to build a (somewhat) functional package.

* Add missing headers.
* Fix segfault caused by an anonymous function being destroyed before it's used.

I found other runtime glitches and segfaults, but won't chase them down without gauging upstream interest in PRs.