### PR TITLE
RP: Regression: MOTION_DEADZONE_OUTER has no effect with MOTION_STICK_MODE=LEFT_STEER_X Issue 125

### DIFF
--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -948,8 +948,10 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 				}
 				float motionDZInner = jc->getSetting(SettingID::MOTION_DEADZONE_INNER);
 				float motionDZOuter = jc->getSetting(SettingID::MOTION_DEADZONE_OUTER);
-				float remappedLeanAngle = pow(clamp((absLeanAngle - motionDZInner) / (180.f - motionDZOuter - motionDZInner), 0.f, 1.f), jc->getSetting(SettingID::STICK_POWER));
 
+				float remappedLeanAngle = pow(clamp(
+					(absLeanAngle / 180.f - motionDZInner) / (1.f - motionDZOuter - motionDZInner)  // motion deadzones are in 0.f to 1.f domain
+				, 0.f, 1.f), jc->getSetting(SettingID::STICK_POWER));
 				// now actually convert to output stick value, taking deadzones and power curve into account
 				float undeadzoneInner, undeadzoneOuter, unpower;
 				if (isLeft)


### PR DESCRIPTION
Small fix for issue 125, resulting from calculation being done in mix of 0-180 degree and 0-1 stick value domains