### PR TITLE
Fix mouseY calculation to use SCREEN_RESOLUTION_Y

### DIFF
--- a/JoyShockMapper/src/JoyShock.cpp
+++ b/JoyShockMapper/src/JoyShock.cpp
@@ -1126,7 +1126,7 @@ void JoyShock::processStick(float stickX, float stickY, Stick &stick, float mous
 			float normY = stickY / stickLength;
 			// use screen resolution
 			float mouseX = getSetting(SettingID::SCREEN_RESOLUTION_X) * 0.5f + 0.5f + normX * mouse_ring_radius;
-			float mouseY = getSetting(SettingID::SCREEN_RESOLUTION_X) * 0.5f + 0.5f - normY * mouse_ring_radius;
+			float mouseY = getSetting(SettingID::SCREEN_RESOLUTION_Y) * 0.5f + 0.5f - normY * mouse_ring_radius;
 			// normalize
 			mouseX = mouseX / getSetting(SettingID::SCREEN_RESOLUTION_X);
 			mouseY = mouseY / getSetting(SettingID::SCREEN_RESOLUTION_Y);


### PR DESCRIPTION
Just fixed a typo where the calculations for the Y axis were using the X axis instead. My friend found it, I fixed it. Lol.